### PR TITLE
fix: annotation cap, sonar impacts, endLine fallback, empty path guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ No `upload-sarif`, no Code Scanning configuration needed — works on every GitH
 
 Severity → annotation level: `Critical` / `High` → `error`, `Moderate` → `warning`, `Low` / `Info` → `notice`.
 
-> **Note:** GitHub caps annotations at 10 errors / 10 warnings / 10 notices per workflow step. For larger result sets, also produce a SARIF or JUnit artifact in the same job — workflow commands are best for surfacing the worst findings inline on a PR, while the artifact is your full record.
+> **Note:** GitHub caps annotations at 10 errors / 10 warnings / 10 notices per workflow step and silently drops the rest. sf-cat enforces a default cap of 50 and prints a warning when violations exceed it. Use `--max-annotations` to adjust. For full results, also produce a SARIF or JUnit artifact in the same job.
 
 ## Failing the Build on High-Severity Findings
 
@@ -238,6 +238,7 @@ sf-cat strips all column values before output. Line-level highlighting is preser
 | `--fail-on`          |       | Exit non-zero when any violation is at this severity or higher: `critical`, `high`, `moderate`, `low`, `info`, or `never` (default)                                   |
 | `--strip-prefix`     |       | Strip a leading path prefix from every violation file path before formatting                                                                                          |
 | `--project-relative` |       | Make every violation file path relative to the SFDX project root (`sfdx-project.json` location)                                                                       |
+| `--max-annotations`  |       | Maximum annotations to emit for `--format github`. Default: `50`. Prints a warning and truncates when total exceeds this limit.                                       |
 
 **Examples:**
 

--- a/messages/transformer.transform.md
+++ b/messages/transformer.transform.md
@@ -40,3 +40,7 @@ Strip a leading prefix from every violation file path before formatting (for exa
 # flags.project-relative.summary
 
 Make every violation file path relative to the Salesforce DX project root (resolved by walking upward from the current directory until an `sfdx-project.json` is found). Mutually exclusive with `--strip-prefix`.
+
+# flags.max-annotations.summary
+
+Maximum number of GitHub Actions workflow command annotations to emit (only applies to `--format github`). GitHub silently drops annotations beyond its per-step cap; this flag lets you control how many are emitted and surfaces a warning when the total exceeds the limit. Defaults to 50.

--- a/src/commands/cat/transform.ts
+++ b/src/commands/cat/transform.ts
@@ -11,6 +11,7 @@ import {
   defaultOutputFiles,
   formatters,
 } from '../../utils/formats/index.js';
+import { GitHubAnnotationReport } from '../../utils/formats/github.js';
 import { FAIL_ON_THRESHOLDS, FailOnThreshold, countAtOrAboveThreshold } from '../../utils/severity.js';
 import { normalizePaths } from '../../utils/normalizePaths.js';
 
@@ -53,6 +54,11 @@ export default class TransformerTransform extends SfCommand<TransformResult> {
       exclusive: ['strip-prefix'],
       default: false,
     }),
+    'max-annotations': Flags.integer({
+      summary: messages.getMessage('flags.max-annotations.summary'),
+      default: 50,
+      min: 1,
+    }),
   };
 
   public async run(): Promise<TransformResult> {
@@ -69,7 +75,21 @@ export default class TransformerTransform extends SfCommand<TransformResult> {
     });
 
     const handler = formatters[format];
-    const serialized = handler.serialize(handler.convert(input));
+    let converted = handler.convert(input);
+
+    if (format === 'github') {
+      const annotations = converted as GitHubAnnotationReport;
+      const maxAnnotations = flags['max-annotations'];
+      if (annotations.length > maxAnnotations) {
+        const dropped = annotations.length - maxAnnotations;
+        this.warn(
+          `${annotations.length} annotations generated; only the first ${maxAnnotations} will be emitted (${dropped} dropped). GitHub silently drops annotations beyond its per-step cap. Increase --max-annotations or use --format sarif/junit for a full artifact.`,
+        );
+        converted = annotations.slice(0, maxAnnotations);
+      }
+    }
+
+    const serialized = handler.serialize(converted);
 
     if (outputPath === STDOUT_SENTINEL) {
       process.stdout.write(serialized);

--- a/src/utils/formats/sonar.ts
+++ b/src/utils/formats/sonar.ts
@@ -1,5 +1,5 @@
 import { CodeAnalyzerOutput } from '../types.js';
-import { mapIssueType, normalizeSeverity, sonarSeverity, IssueType } from '../severity.js';
+import { mapIssueType, normalizeSeverity, sonarSeverity, IssueType, mapSonarSoftwareQualities } from '../severity.js';
 
 export type SonarQubeIssue = {
   ruleId: string;
@@ -58,8 +58,8 @@ export function convertToSonarQube(input: CodeAnalyzerOutput): SonarQubeReport {
         cleanCodeAttribute: 'FORMATTED',
         type: issueType,
         severity,
-        impacts: v.tags.map((tag) => ({
-          softwareQuality: tag.toUpperCase(),
+        impacts: mapSonarSoftwareQualities(v.tags).map((softwareQuality) => ({
+          softwareQuality,
           severity: 'MEDIUM',
         })),
       });
@@ -77,7 +77,7 @@ export function convertToSonarQube(input: CodeAnalyzerOutput): SonarQubeReport {
         filePath: loc.file.replace(/\\/g, '/'),
         textRange: {
           startLine: loc.startLine,
-          endLine: loc.endLine,
+          endLine: loc.endLine ?? loc.startLine,
         },
       },
     });

--- a/src/utils/normalizePaths.ts
+++ b/src/utils/normalizePaths.ts
@@ -42,7 +42,6 @@ export function normalizePaths(input: CodeAnalyzerOutput, opts: PathRewriteOptio
 
 function stripLeadingPrefix(file: string, prefix: string): string {
   const normalized = file.replace(/\\/g, '/');
-  if (normalized === prefix) return '';
   if (normalized.startsWith(`${prefix}/`)) {
     return normalized.slice(prefix.length + 1);
   }

--- a/src/utils/severity.ts
+++ b/src/utils/severity.ts
@@ -56,6 +56,20 @@ export type CodeClimateCategory =
   | 'Security'
   | 'Style';
 
+// SonarQube only accepts these three values for softwareQuality.
+const TAG_TO_SONAR_QUALITY: Record<string, string> = {
+  security: 'SECURITY',
+  errorprone: 'RELIABILITY',
+  reliability: 'RELIABILITY',
+  performance: 'RELIABILITY',
+  design: 'MAINTAINABILITY',
+  documentation: 'MAINTAINABILITY',
+  portability: 'MAINTAINABILITY',
+  bestpractices: 'MAINTAINABILITY',
+  codestyle: 'MAINTAINABILITY',
+  maintainability: 'MAINTAINABILITY',
+};
+
 const TAG_TO_CATEGORY: Record<string, CodeClimateCategory> = {
   security: 'Security',
   errorprone: 'Bug Risk',
@@ -120,6 +134,21 @@ export function normalizeSeverity(severity: number): NormalizedSeverity {
  * Aligned with COMMON_TAGS.CATEGORIES from code-analyzer-engine-api:
  * https://github.com/forcedotcom/code-analyzer-core/blob/dev/packages/code-analyzer-engine-api/src/rules.ts
  */
+/**
+ * Maps Code Analyzer tags to valid SonarQube softwareQuality values.
+ * SonarQube rejects any value outside MAINTAINABILITY, RELIABILITY, SECURITY.
+ * Deduplicates; falls back to ['MAINTAINABILITY'] when no tags match.
+ */
+export function mapSonarSoftwareQualities(tags: string[]): string[] {
+  const out = new Set<string>();
+  for (const tag of tags) {
+    const q = TAG_TO_SONAR_QUALITY[tag.toLowerCase()];
+    if (q) out.add(q);
+  }
+  if (out.size === 0) out.add('MAINTAINABILITY');
+  return Array.from(out);
+}
+
 export function mapIssueType(tags: string[]): IssueType {
   const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
   if (tagSet.has('security')) return 'VULNERABILITY';

--- a/test/commands/cat/transform.test.ts
+++ b/test/commands/cat/transform.test.ts
@@ -805,6 +805,31 @@ describe('serializeGitHubAnnotations unit tests', () => {
     expect(lines[0].startsWith('::error ')).toBe(true);
     expect(lines[1].startsWith('::notice ')).toBe(true);
   });
+
+  it('serializeGitHubAnnotations should emit all annotations when count is within limit', () => {
+    const annotations = convertToGitHubAnnotations(mockAnalyzerInput);
+    const out = serializeGitHubAnnotations(annotations.slice(0, 50));
+    expect(out.trimEnd().split('\n')).toHaveLength(annotations.length);
+  });
+
+  it('slicing annotations to max-annotations cap should truncate output', () => {
+    const input: CodeAnalyzerOutput = {
+      violations: Array.from({ length: 5 }, (_, i) => ({
+        rule: `R${i}`,
+        engine: 'pmd',
+        severity: 2,
+        tags: ['security'],
+        primaryLocationIndex: 0,
+        message: `msg${i}`,
+        locations: [{ file: `file${i}.cls`, startLine: i + 1 }],
+      })),
+    };
+    const all = convertToGitHubAnnotations(input);
+    expect(all).toHaveLength(5);
+    const capped = all.slice(0, 3);
+    const out = serializeGitHubAnnotations(capped);
+    expect(out.trimEnd().split('\n')).toHaveLength(3);
+  });
 });
 
 describe('countAtOrAboveThreshold unit tests', () => {
@@ -899,10 +924,12 @@ describe('normalizePaths unit tests', () => {
     expect(out.violations[0].locations[0].file).toBe('/reports/X.cls');
   });
 
-  it('should reduce the path to "" when it equals the prefix exactly', () => {
+  it('should leave the path unchanged when it equals the prefix exactly (no valid relative path)', () => {
+    // A file path identical to the prefix has no meaningful relative form — return as-is
+    // rather than producing an empty string that all downstream formatters would mishandle.
     const input = buildInput('/repo');
     const out = normalizePaths(input, { stripPrefix: '/repo' });
-    expect(out.violations[0].locations[0].file).toBe('');
+    expect(out.violations[0].locations[0].file).toBe('/repo');
   });
 
   it('should handle multi-violation, multi-location inputs', () => {

--- a/test/commands/cat/transform.test.ts
+++ b/test/commands/cat/transform.test.ts
@@ -12,7 +12,7 @@ import { convertToSarif } from '../../../src/utils/formats/sarif.js';
 import { convertToCodeClimate } from '../../../src/utils/formats/codeclimate.js';
 import { convertToJUnit, serializeJUnit } from '../../../src/utils/formats/junit.js';
 import { convertToGitHubAnnotations, serializeGitHubAnnotations } from '../../../src/utils/formats/github.js';
-import { countAtOrAboveThreshold } from '../../../src/utils/severity.js';
+import { countAtOrAboveThreshold, mapSonarSoftwareQualities } from '../../../src/utils/severity.js';
 import { normalizePaths } from '../../../src/utils/normalizePaths.js';
 import { CodeAnalyzerOutput } from '../../../src/utils/types.js';
 
@@ -157,6 +157,49 @@ describe('convertToSonarQube unit tests', () => {
     await writeFile(tempOutputPath, JSON.stringify(output, null, 2));
     const parsed = JSON.parse(await readFile(tempOutputPath, 'utf8')) as SonarQubeReport;
     expect(parsed).toEqual(output);
+  });
+
+  it('should use startLine as endLine when violation has no endLine', () => {
+    const input: CodeAnalyzerOutput = {
+      violations: [
+        {
+          rule: 'NoEndLine',
+          engine: 'pmd',
+          severity: 3,
+          tags: ['bestpractices'],
+          primaryLocationIndex: 0,
+          message: 'Missing end line.',
+          locations: [{ file: 'force-app/main/default/classes/X.cls', startLine: 7 }],
+        },
+      ],
+    };
+    const output = convertToSonarQube(input);
+    expect(output.issues[0].primaryLocation.textRange).toEqual({ startLine: 7, endLine: 7 });
+  });
+});
+
+describe('mapSonarSoftwareQualities unit tests', () => {
+  it('should fall back to MAINTAINABILITY when no tags match known sonar qualities', () => {
+    expect(mapSonarSoftwareQualities([])).toEqual(['MAINTAINABILITY']);
+    expect(mapSonarSoftwareQualities(['unknowntag', 'anotherbadtag'])).toEqual(['MAINTAINABILITY']);
+  });
+
+  it('should map known tags to valid SonarQube softwareQuality values', () => {
+    expect(mapSonarSoftwareQualities(['security'])).toEqual(['SECURITY']);
+    expect(mapSonarSoftwareQualities(['errorprone'])).toEqual(['RELIABILITY']);
+    expect(mapSonarSoftwareQualities(['maintainability'])).toEqual(['MAINTAINABILITY']);
+  });
+
+  it('should deduplicate qualities when multiple tags map to the same value', () => {
+    const result = mapSonarSoftwareQualities(['errorprone', 'reliability', 'performance']);
+    expect(result).toEqual(['RELIABILITY']);
+  });
+
+  it('should return multiple qualities when tags map to different values', () => {
+    const result = mapSonarSoftwareQualities(['security', 'errorprone']);
+    expect(result).toContain('SECURITY');
+    expect(result).toContain('RELIABILITY');
+    expect(result).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- **`--max-annotations` flag** (default `50`) for `--format github`: warns and truncates when total annotations exceed the limit, so users know GitHub silently drops the remainder instead of failing silently
- **`sonar.ts` `impacts.softwareQuality`** was passing arbitrary uppercased tag names (e.g. `ERRORPRONE`, `BESTPRACTICES`) that SonarQube rejects — now maps to the only valid values: `MAINTAINABILITY`, `RELIABILITY`, `SECURITY`
- **`sonar.ts` `endLine`** was passing `undefined` when missing — now falls back to `startLine`, consistent with all other formatters
- **`normalizePaths`** was returning `''` when the file path exactly equalled the strip prefix — now returns the original path to prevent blank file paths in all downstream formatters

## Test plan

- [ ] All 63 unit tests pass (`npm run test:only`)
- [ ] `--max-annotations` truncation warning fires when violation count exceeds the cap
- [ ] `--max-annotations 5` with 10 violations emits exactly 5 annotation lines to stdout
- [ ] SonarQube output `impacts[].softwareQuality` values are only `MAINTAINABILITY`, `RELIABILITY`, or `SECURITY`
- [ ] `sonar` format output for violations with no `endLine` has `endLine` equal to `startLine`
- [ ] `--strip-prefix /repo` with a file path of exactly `/repo` leaves the path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)